### PR TITLE
Makefile: generate PY_MOD_DIR in a way compatible with python 3 (and 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CC = gcc
 AR = ar
 
 PY_SRCDIR = pydablooms
-PY_MOD_DIR := $(shell $(PYTHON) -c "import distutils.sysconfig ; print distutils.sysconfig.get_python_lib()")
+PY_MOD_DIR := $(shell $(PYTHON) -c "import distutils.sysconfig ; print(distutils.sysconfig.get_python_lib())")
 PY_FLAGS = --build-lib=$(PY_BLDDIR) --build-temp=$(PY_BLDDIR)
 PY_BLDDIR = $(BLDDIR)/python
 


### PR DESCRIPTION
pydablooms isn't compatible with python 3 yet, but it's nice if the default python doesn't cause the Makefile to print errors even when not making pydablooms
