### PR TITLE
scaling_bloom_flush always returns 1

### DIFF
--- a/src/dablooms.c
+++ b/src/dablooms.c
@@ -488,8 +488,7 @@ int scaling_bloom_check(scaling_bloom_t *bloom, const char *s)
 
 int scaling_bloom_flush(scaling_bloom_t *bloom)
 {
-    bitmap_flush(bloom->bitmap);
-    return 1;
+    return bitmap_flush(bloom->bitmap);
 }
 
 scaling_bloom_t *scaling_bloom_init(unsigned int capacity, double error_rate, const char *filename, int fd)


### PR DESCRIPTION
edit scaling_bloom_flush to return bitmap_flush
