### PR TITLE
some tiny cleanups

### DIFF
--- a/src/dablooms.c
+++ b/src/dablooms.c
@@ -143,8 +143,8 @@ int bitmap_increment(bitmap_t *bitmap, unsigned int index, unsigned int offset)
 int bitmap_decrement(bitmap_t *bitmap, unsigned int index, unsigned int offset)
 {
     uint32_t access = index / 2 + offset;
-    uint32_t temp;
-    uint32_t n = bitmap->array[access];
+    uint8_t temp;
+    uint8_t n = bitmap->array[access];
     
     if (index % 2 != 0) {
         temp = (n & 0x0f);

--- a/src/dablooms.h
+++ b/src/dablooms.h
@@ -64,7 +64,6 @@ typedef struct {
     unsigned int capacity;
     unsigned int num_blooms;
     size_t num_bytes;
-    size_t size;
     double error_rate;
     int fd;
     counting_bloom_t **blooms;


### PR DESCRIPTION
scaling_bloom_t.size is never used
bitmap_decrement should use uint8_t
