### PR TITLE
Faster hash_func. No need for salts.

### DIFF
--- a/src/dablooms.h
+++ b/src/dablooms.h
@@ -35,9 +35,7 @@ typedef struct {
     unsigned int capacity;
     unsigned int offset;
     unsigned int counts_per_func;
-    unsigned int num_salts;
     uint32_t *hashes;
-    uint32_t *salts;
     size_t nfuncs;
     size_t size;
     size_t num_bytes;


### PR DESCRIPTION
The performance bottleneck is in calling the hash function repeatedly. The solution is to call it less frequently. This paper (http://www.eecs.harvard.edu/~michaelm/postscripts/rsa2008.pdf) says you can replace the expensive calls to a hash function with the equation: gi(x) = h1(x) + i \* h2(x). Both h1 and h2 are generated by one call to the hash function. Then you just loop around that equation to generate all the hash values you need for the bloom filter. In my limited testing, performance improves about 20%.
