### PR TITLE
Support 'key in bloom' in Python wrapper.

### DIFF
--- a/pydablooms/pydablooms.c
+++ b/pydablooms/pydablooms.c
@@ -45,6 +45,16 @@ static int Dablooms_init(Dablooms *self, PyObject *args, PyObject *kwds)
     return 0;
 }
 
+static int contains(Dablooms *self, PyObject *key)
+{
+    if (!PyString_Check(key)) {
+      return 0; /* return False */
+    }
+    return scaling_bloom_check(self->filter,
+                               PyString_AsString(key),
+                               (int)PyString_Size(key));
+}
+
 static PyObject *check(Dablooms *self, PyObject *args)
 {
     const char *hash;
@@ -113,6 +123,17 @@ static PyMemberDef Dablooms_members[] = {
     {NULL}  /* Sentinel */
 };
 
+static PySequenceMethods Dablooms_sequence = {
+  NULL,                 /*sq_length*/
+  NULL,                 /*sq_concat*/
+  NULL,                 /*sq_repeat*/
+  NULL,                 /*sq_item*/
+  NULL,                 /*sq_slice*/
+  NULL,                 /*sq_ass_item*/
+  NULL,                 /*sq_ass_slice*/
+  (objobjproc)contains, /*sq_contains*/
+};
+
 static PyTypeObject DabloomsType = {
     PyObject_HEAD_INIT(NULL)
     0,                              /*ob_size*/
@@ -126,7 +147,7 @@ static PyTypeObject DabloomsType = {
     0,                              /*tp_compare*/
     0,                              /*tp_repr*/
     0,                              /*tp_as_number*/
-    0,                              /*tp_as_sequence*/
+    &Dablooms_sequence,             /*tp_as_sequence*/
     0,                              /*tp_as_mapping*/
     0,                              /*tp_hash*/
     0,                              /*tp_call*/

--- a/pydablooms/test_pydablooms.py
+++ b/pydablooms/test_pydablooms.py
@@ -46,7 +46,11 @@ words_file.seek(0)
 i = 0
 for line in words_file:
     exists = bloom.check(line.rstrip())
-    
+    contains = line.rstrip() in bloom
+    assert exists == contains, \
+        "ERROR: %r from 'bloom.check(x)', %i from 'x in bloom'" \
+        % (exists, contains)
+
     if i % 5 == 0:
         if exists:
             false_positives += 1


### PR DESCRIPTION
It is more Pythonic to write:

```
key in bloom
```

than

```
bloom.check(key)
```

Support for 'in' is normally implemented via a __contains__ method for a class written in Python, but here we are using the C API, this the patch implements a sq_contains slot function.

Note this implementation only looks for strings (anything else returns False).

Also note this is the first time I've tried implementing 'in' via the Python C API, please review with care.

As a bonus this seems to make membership testing faster :)
