### PR TITLE
reduce error tightening ratio to 0.499

### DIFF
--- a/src/dablooms.c
+++ b/src/dablooms.c
@@ -18,7 +18,7 @@
 
 #define DABLOOMS_VERSION "0.8.2"
 
-#define ERROR_TIGHTENING_RATIO .7
+#define ERROR_TIGHTENING_RATIO 0.5
 #define SALT_CONSTANT 0x97c29b3a
 
 const char *dablooms_version(void)


### PR DESCRIPTION
necessary for scaling bloom's false-positive rate to not increase
well beyond the desired error rate when multiple levels are full

setting it at exactly 0.5 caused a segfault I don't understand
