### PR TITLE
Make Destroy public

### DIFF
--- a/godablooms/dablooms.go
+++ b/godablooms/dablooms.go
@@ -41,7 +41,7 @@ func NewScalingBloomFromFile(capacity C.uint, errorRate C.double, filename strin
 // apparently this is an unsupported feature of cgo
 // we should probably use runtime.SetFinalizer
 // see: https://groups.google.com/forum/?fromgroups#!topic/golang-dev/5cD0EmU2voI
-func (sb *ScalingBloom) destroy() {
+func (sb *ScalingBloom) Destroy() {
 	C.free_scaling_bloom(sb.cfilter)
 }
 


### PR DESCRIPTION
I think this method needs to be public in order for the backing files to be closed. According to lsof on my system, simply freeing the Go object leaves the file descriptor open forever. I happen to always know when my filter is going to go out of scope, so I can call Destroy and make sure the fds get freed.